### PR TITLE
doc: fix README example to use named import `cesiumEngine`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Add the plugin to your Vite config — that's it.
 ```ts
 // vite.config.ts
 import { defineConfig } from "vite";
-import cesiumEngine from "vite-plugin-cesium-engine";
+import { cesiumEngine } from "vite-plugin-cesium-engine";
 
 export default defineConfig({
   plugins: [cesiumEngine()],


### PR DESCRIPTION
The package only provides a named export, so the README example used an incorrect default import.
This change replaces it with the named import, fixing the runtime error:

```
SyntaxError: The requested module '…/vite-plugin-cesium-engine.js' does not provide an export named 'default'
```