### PR TITLE
Fix CommonJS package entrypoint

### DIFF
--- a/.changeset/fix-cjs-entrypoint.md
+++ b/.changeset/fix-cjs-entrypoint.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-cesium-engine": patch
+---
+
+Fix the CommonJS package entrypoint to match the emitted build artifact.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dist",
     "virtual.d.ts"
   ],
-  "main": "./dist/vite-plugin-cesium-engine.umd.cjs",
+  "main": "./dist/vite-plugin-cesium-engine.cjs",
   "module": "./dist/vite-plugin-cesium-engine.js",
   "types": "./dist/src/index.d.ts",
   "exports": {
@@ -33,7 +33,7 @@
       "development": "./src/index.ts",
       "types": "./dist/src/index.d.ts",
       "import": "./dist/vite-plugin-cesium-engine.js",
-      "require": "./dist/vite-plugin-cesium-engine.umd.cjs"
+      "require": "./dist/vite-plugin-cesium-engine.cjs"
     },
     "./virtual": {
       "types": "./virtual.d.ts"


### PR DESCRIPTION
## Summary

- Point the CommonJS package entrypoints at the CJS file emitted by the current Vite build.
- Keep the existing ESM and type entrypoints unchanged.

## Why

`vite build` emits `dist/vite-plugin-cesium-engine.cjs`, but `package.json` currently advertises `dist/vite-plugin-cesium-engine.umd.cjs` through both `main` and `exports["."].require`. That makes `require("vite-plugin-cesium-engine")` fail in a clean CommonJS consumer even though ESM import works.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm test` (65 passing)
- `pnpm pack` and install the tarball into a clean temp project
- verified `import("vite-plugin-cesium-engine")` succeeds
- verified `require("vite-plugin-cesium-engine")` succeeds
- verified `main`, `exports.require`, `exports.import`, and `exports.types` all point at files present in the packed package
