### PR TITLE
feat: make package and output paths Vite-root-aware

### DIFF
--- a/.changeset/root-aware-engine-paths.md
+++ b/.changeset/root-aware-engine-paths.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-cesium-engine": minor
+---
+
+Resolve the Cesium package and build output paths relative to Vite's configured root, and add an `enginePath` option for non-standard package locations.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ cesiumEngine({
   // Override where assets are copied to in the output dir (default: "cesium")
   assetsPath: "static/cesium",
 
+  // Override the @cesium/engine package directory (relative to Vite's root)
+  enginePath: "../vendor/cesium-engine",
+
   // Split @cesium/engine into its own named chunk (optional)
   chunkName: "vendor-cesium",
 
@@ -97,6 +100,7 @@ cesiumEngine({
 | `ionToken` | `string \| Record<string, string> \| (mode) => string \| Promise<string>` | `undefined` | Ion access token. String, per-mode map, or sync/async callback. Omit to auto-read from `.env`. |
 | `cesiumBaseUrl` | `string` | `"/${assetsPath}"` | URL path from which Cesium assets are served. Defaults to Vite's `base` + `assetsPath`. |
 | `assetsPath` | `string` | `"cesium"` | Output subfolder (relative to `build.outDir`) where static assets are copied. |
+| `enginePath` | `string` | `"node_modules/@cesium/engine"` | Package directory, resolved relative to Vite's `root`. Absolute paths are also supported. |
 | `chunkName` | `string` | `undefined` | Split `@cesium/engine` into a dedicated output chunk with this name. Omit to bundle Cesium with your app. |
 | `debug` | `boolean` | `false` | Log asset copy targets, resolved token, and base URL at startup. |
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -880,9 +880,7 @@ describe("closeBundle hook", () => {
     const destinations = vi
       .mocked(fs.cpSync)
       .mock.calls.map(([, destination]) => String(destination));
-    expect(
-      destinations.some((destination) => destination.startsWith("/workspace/app/output")),
-    ).toBe(true);
+    expect(destinations).toContain(resolve("/workspace/app", "output", "cesium"));
   });
 
   it("emits debug logs for each copy operation when debug: true", async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -37,7 +37,7 @@ vi.mock("node:path", async () => {
 
 // ─── Imports after mocks are set up ──────────────────────────────────────────
 import * as fs from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import type { Plugin, ResolvedConfig, UserConfig, ViteDevServer } from "vite";
 
 // ─── Types re-used across tests ───────────────────────────────────────────────
@@ -63,6 +63,7 @@ function makeResolvedConfig(overrides: Partial<ResolvedConfig> = {}): Partial<Re
     mode: "production",
     command: "build",
     base: "/",
+    root: process.cwd(),
     build: { outDir: "dist" } as ResolvedConfig["build"],
     env: {},
     ...overrides,
@@ -125,7 +126,33 @@ describe("cesiumEngine()", () => {
   it("throws when @cesium/engine is not installed", async () => {
     vi.mocked(fs.existsSync).mockReturnValue(false);
     const { cesiumEngine } = await import("./index.js");
-    expect(() => cesiumEngine()).toThrow(/@cesium\/engine/);
+    const plugin = cesiumEngine() as unknown as PluginWithHooks;
+    expect(() => plugin.configResolved(makeResolvedConfig() as ResolvedConfig)).toThrow(
+      /@cesium\/engine/,
+    );
+  });
+
+  it("resolves @cesium/engine from Vite's root", async () => {
+    const { cesiumEngine } = await import("./index.js");
+    const plugin = cesiumEngine() as unknown as PluginWithHooks;
+    plugin.configResolved(makeResolvedConfig({ root: "/workspace/app" }) as ResolvedConfig);
+
+    expect(fs.existsSync).toHaveBeenCalledWith(
+      resolve("/workspace/app", "node_modules/@cesium/engine"),
+    );
+  });
+
+  it("resolves a relative enginePath from Vite's root", async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    const { cesiumEngine } = await import("./index.js");
+    const plugin = cesiumEngine({
+      enginePath: "../vendor/cesium-engine",
+    }) as unknown as PluginWithHooks;
+    plugin.configResolved(makeResolvedConfig({ root: "/workspace/app" }) as ResolvedConfig);
+
+    expect(fs.existsSync).toHaveBeenCalledWith(
+      resolve("/workspace/app", "../vendor/cesium-engine"),
+    );
   });
 
   it("falls back to 'unknown' version when package.json cannot be read", async () => {
@@ -837,6 +864,25 @@ describe("closeBundle hook", () => {
     const mkdirArgs = vi.mocked(fs.mkdirSync).mock.calls.map(([p]) => String(p));
     const allDest = [...destArgs, ...mkdirArgs];
     expect(allDest.some((d) => d.includes(join("public", "cesium")))).toBe(true);
+  });
+
+  it("resolves build.outDir from Vite's root", async () => {
+    const plugin = await buildPlugin(
+      {},
+      {
+        command: "build",
+        root: "/workspace/app",
+        build: { outDir: "output" } as ResolvedConfig["build"],
+      },
+    );
+    plugin.closeBundle();
+
+    const destinations = vi
+      .mocked(fs.cpSync)
+      .mock.calls.map(([, destination]) => String(destination));
+    expect(
+      destinations.some((destination) => destination.startsWith("/workspace/app/output")),
+    ).toBe(true);
   });
 
   it("emits debug logs for each copy operation when debug: true", async () => {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -22,6 +22,7 @@ export function cesiumEngine(options: CesiumEngineOptions = {}): Plugin {
     ionToken: ionTokenConfig,
     cesiumBaseUrl: cesiumBaseUrlOption,
     assetsPath = "cesium",
+    enginePath,
     chunkName,
     debug = false,
   } = options;
@@ -31,27 +32,7 @@ export function cesiumEngine(options: CesiumEngineOptions = {}): Plugin {
   let cesiumBaseUrl: string;
   let resolvedConfig: ResolvedConfig;
   let installedCesiumVersion: string;
-
-  // ── Peer dependency check ───────────────────────────────────────────────────
-  const engineRoot = resolve(process.cwd(), "node_modules/@cesium/engine");
-  if (!existsSync(engineRoot)) {
-    throw new Error(
-      "[cesium-engine] Could not find @cesium/engine in node_modules.\n" +
-        "Install it as a dependency:\n\n" +
-        "  npm i @cesium/engine\n" +
-        "  # or: pnpm add @cesium/engine\n",
-    );
-  }
-
-  // Read installed version from @cesium/engine's own package.json
-  try {
-    const pkgJson = JSON.parse(readFileSync(join(engineRoot, "package.json"), "utf-8")) as {
-      version: string;
-    };
-    installedCesiumVersion = pkgJson.version;
-  } catch {
-    installedCesiumVersion = "unknown";
-  }
+  let engineRoot: string;
 
   return {
     name: "vite-plugin-cesium-engine",
@@ -85,6 +66,30 @@ export function cesiumEngine(options: CesiumEngineOptions = {}): Plugin {
       resolvedConfig = cfg;
       const { mode } = cfg;
 
+      // Project-relative paths follow Vite's root, which can differ from the
+      // process working directory in monorepos and programmatic builds.
+      engineRoot = enginePath
+        ? resolve(cfg.root, enginePath)
+        : resolve(cfg.root, "node_modules/@cesium/engine");
+
+      if (!existsSync(engineRoot)) {
+        throw new Error(
+          `[cesium-engine] Could not find @cesium/engine at ${engineRoot}.\n` +
+            "Install it as a dependency or set the enginePath option:\n\n" +
+            "  npm i @cesium/engine\n" +
+            "  # or: pnpm add @cesium/engine\n",
+        );
+      }
+
+      try {
+        const pkgJson = JSON.parse(readFileSync(join(engineRoot, "package.json"), "utf-8")) as {
+          version: string;
+        };
+        installedCesiumVersion = pkgJson.version;
+      } catch {
+        installedCesiumVersion = "unknown";
+      }
+
       // Build CESIUM_BASE_URL: explicit option wins, then derive from Vite base.
       const viteBase = (cfg.base ?? "").replace(/\/$/, "");
       cesiumBaseUrl = cesiumBaseUrlOption
@@ -104,6 +109,7 @@ export function cesiumEngine(options: CesiumEngineOptions = {}): Plugin {
         log(`vite base    : "${viteBase || "(empty)"}"`);
         log(`cesiumBaseUrl: "${cesiumBaseUrl}"`);
         log(`assetsPath   : "${assetsPath}"`);
+        log(`enginePath   : "${engineRoot}"`);
       }
     },
 
@@ -132,7 +138,7 @@ export function cesiumEngine(options: CesiumEngineOptions = {}): Plugin {
     // in both one-shot build and --watch mode.
     closeBundle() {
       if (resolvedConfig.command !== "build") return;
-      const outDir = resolve(process.cwd(), resolvedConfig.build.outDir);
+      const outDir = resolve(resolvedConfig.root, resolvedConfig.build.outDir);
       copyCesiumAssets(engineRoot, outDir, assetsPath, debug);
     },
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,17 @@ export type CesiumEngineOptions = {
   assetsPath?: string;
 
   /**
+   * Path to the `@cesium/engine` package directory. Relative paths are
+   * resolved from Vite's configured `root`.
+   *
+   * Use this when the package is installed in a non-standard location, such
+   * as a workspace-managed or vendored dependency directory.
+   *
+   * @default "node_modules/@cesium/engine"
+   */
+  enginePath?: string;
+
+  /**
    * Split `@cesium/engine` into a dedicated output chunk with this name,
    * keeping it independently cacheable from your app code.
    *


### PR DESCRIPTION
## Summary

- Resolve `@cesium/engine` relative to Vite’s configured `root`
- Resolve `build.outDir` relative to Vite’s `root`
- Add an optional `enginePath` override for non-standard package locations
- Resolve relative `enginePath` values from Vite’s root while supporting absolute paths
- Move engine validation and version detection into `configResolved`
- Document the new option and include a minor-release changeset

## Motivation

The plugin previously resolved the Cesium package and build output directory from `process.cwd()`. This produced incorrect paths when Vite’s `root` differed from the current working directory, particularly in monorepos and programmatic builds.

## Example

```ts
cesiumEngine({
  enginePath: "../vendor/cesium-engine",
})
```

## Validation

- pnpm test — 80 tests passed
- pnpm build — passed
- pnpm build:all — React, Svelte, Vanilla TypeScript, and Vue examples passed
- Verified Cesium assets were copied into every example’s build output
